### PR TITLE
Added Path of the Beast

### DIFF
--- a/src/Classes/Barbarian/Subclasses/BarbarianSubclass.ts
+++ b/src/Classes/Barbarian/Subclasses/BarbarianSubclass.ts
@@ -6,6 +6,8 @@ import { StormHerald } from "./StormHerald/StormHerald";
 import { Zealot } from "./Zealot/Zealot";
 import { LevelingParams } from "Classes/PlayerClass";
 import { PlayerCharacter } from "index";
+import { Beast } from "./Beast/Beast";
+
 export class BarbarianSubclass extends Subclass {
 
   constructor(subclassSelection: {subclass: string, options?: string[]}){
@@ -19,6 +21,12 @@ export class BarbarianSubclass extends Subclass {
       "6": Berserker.berserker6,
       "10": Berserker.berserker10,
       "14": Berserker.berserker14,
+    },
+    BEAST: {
+      "3": Beast.beast3,
+      "6": Beast.beast6,
+      "10": Beast.beast10,
+      "14": Beast.beast14,
     },
     ZEALOT: {
       "3": Zealot.zealot3,

--- a/src/Classes/Barbarian/Subclasses/Beast/Beast.json
+++ b/src/Classes/Barbarian/Subclasses/Beast/Beast.json
@@ -1,0 +1,30 @@
+{
+  "title": "Beast", 
+  "description": "Barbarians who walk the Path of the Beast draw their rage from a bestial spark burning within their souls. That beast bursts forth in the throes of rage, physically transforming the barbarian. Such a barbarian might be inhabited by a primal spirit or be descended from shape-shifters. You can choose the origin of your feral might or determine it by rolling on the Origin of the Beast table.", 
+  "features": {
+    "3": {
+      "FORM OF THE BEAST": {
+        "title": "Form of the Beast", 
+        "description": "When you enter your rage, you can transform, revealing the bestial power within you. Until the rage ends, you manifest a natural weapon. It counts as a simple melee weapon for you, and you add your Strength modifier to the attack and damage rolls when you attack with it, as normal.\nYou choose the weapon's form each time you rage:\nBite. Your mouth transforms into a bestial muzzle or great mandibles (your choice). It deals 1d8 piercing damage on a hit. Once on each of your turns when you damage a creature with this bite, you regain a number of hit points equal to your proficiency bonus, provided you have less than half your hit points when you hit.\nClaws. Each of your hands transforms into a claw, which you can use as a weapon if it's empty. It deals 1d6 slashing damage on a hit. Once on each of your turns when you attack with a claw using the Attack action, you can make one additional claw attack as part of the same action.\nTail. You grow a lashing, spiny tail, which deals 1d8 piercing damage on a hit and has the reach property. If a creature you can see within 10 feet of you hits you with an attack roll, you can use your reaction to swipe your tail and roll a d8, applying a bonus to your AC equal to the number rolled, potentially causing the attack to miss you."
+      }
+    }, 
+    "6": {
+      "BESTIAL SOUL": {
+        "title": "Bestial Soul", 
+        "description": "The feral power within you increases, causing the natural weapons of your Form of the Beast to count as magical for the purpose of overcoming resistance and immunity to nonmagical attacks and damage.\nYou can also alter your form to help you adapt to your surroundings. When you finish a short or long rest, choose one of the following benefits, which lasts until you finish your next short or long rest:\nYou gain a swimming speed equal to your walking speed, and you can breathe underwater.\nYou gain a climbing speed equal to your walking speed, and you can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check.\nWhen you jump, you can make a Strength (Athletics) check and extend your jump by a number of feet equal to the check's total. You can make this special check only once per turn."
+      }
+    }, 
+    "10": {
+      "INFECTIOUS FURY": {
+        "title": "Infectious Fury", 
+        "description": "When you hit a creature with your natural weapons while you are raging, the beast within you can curse your target with rabid fury. The target must succeed on a Wisdom saving throw (DC equal to 8 + your Constitution modifier + your proficiency bonus) or suffer one of the following effects (your choice):\nThe target must use its reaction to make a melee attack against another creature of your choice that you can see.\nThe target takes 2d12 psychic damage.\nYou can use this feature a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
+      }
+    }, 
+    "14": {
+      "CALL THE HUNT": {
+        "title": "Call the Hunt", 
+        "description": "The beast within you grows so powerful that you can spread its ferocity to others and gain resilience from them joining your hunt. When you enter your rage, you can choose a number of other willing creatures you can see within 30 feet of you equal to your Constitution modifier (minimum of one creature).\nYou gain 5 temporary hit points for each creature that accepts this feature. Until the rage ends, the chosen creatures can each use the following benefit once on each of their turns: when the creature hits a target with an attack roll and deals damage to it, the creature can roll a d6 and gain a bonus to the damage equal to the number rolled.\nYou can use this feature a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
+      }
+    }
+  }
+}

--- a/src/Classes/Barbarian/Subclasses/Beast/Beast.ts
+++ b/src/Classes/Barbarian/Subclasses/Beast/Beast.ts
@@ -1,0 +1,35 @@
+import { ResourceTrait, ScalingTrait } from "../../../../Base/Interfaces";
+import { PlayerCharacter } from "../../../../Base/PlayerCharacter";
+import { LevelingParams } from "../../../PlayerClass";
+import * as BeastDict from "./Beast.json";
+
+export class Beast {
+
+  static getFeature(level: string, featureName: string) {
+      return BeastDict["features"][level][featureName];
+  }
+
+  static beast3(pc: PlayerCharacter, params: LevelingParams) {
+    pc.pcHelper.addFeatures(Beast.getFeature("3", "FORM OF THE BEAST"));
+  }
+
+  static beast6(pc: PlayerCharacter, params: LevelingParams) {
+    pc.pcHelper.addFeatures(Beast.getFeature("6", "BESTIAL SOUL"));
+  }
+
+  static beast10(pc: PlayerCharacter, params: LevelingParams) {
+    pc.pcHelper.addFeatures(Beast.getFeature("10", "INFECTIOUS FURY"));
+  }
+  
+  static beast14(pc: PlayerCharacter, params: LevelingParams) {
+    pc.pcHelper.addFeatures(Beast.getFeature("14", "CALL THE HUNT"));
+    const hunt: ResourceTrait = {
+      title: "Call the Hunt",
+      description: "The number of willing creatures you can target, bonus damage dice, and uses for Call the Hunt",
+      dice: "d6",
+      bonus: pc.abilityScores.constitution.modifier.value,
+      resourceMax: pc.proficiency.baseBonus
+    }
+    pc.pcHelper.addResourceTraits(hunt);
+  }
+}

--- a/src/Classes/Wizard/Subclasses/WizardSubclass.ts
+++ b/src/Classes/Wizard/Subclasses/WizardSubclass.ts
@@ -1,4 +1,3 @@
-import { WarCaster } from "Feats/Feat";
 import { Subclass } from "../../Subclass";
 import { Abjuration } from "./Abjuration/Abjuration";
 import { Conjuration } from "./Conjuration/Conjuration";


### PR DESCRIPTION
One potential issue.
Call the Hunt (feature) caps numbers of willing creature you can target by constitution modifier, and then maximum uses per long rest by proficiency score. In a perfect world, the constitution would be a reference, however, since resource traits only have one attribute that can be boxed, I made it a straight literal. You only have 2 more ASI after 14, and the number of people who will get this high can probably be counted on one hand.
Make a function to update the modifier on ASI levels or no?