### PR TITLE
Added Eloquence

### DIFF
--- a/src/Classes/Bard/Subclasses/BardSubclass.ts
+++ b/src/Classes/Bard/Subclasses/BardSubclass.ts
@@ -4,7 +4,7 @@ import { CollegeOfLore } from "./Lore/CollegeOfLore";
 import { CollegeOfSwords } from "./Swords/CollegeOfSwords";
 import { CollegeOfValor } from "./Valor/CollegeOfValor";
 import { CollegeOfWhispers } from "./Whispers/CollegeOfWhispers";
-
+import { CollegeOfEloquence } from "./Eloquence/CollegeOfEloquence";
 export class BardSubclass extends Subclass {
 
   constructor(subclassSelection: {subclass: string, options?: string[]}){
@@ -29,6 +29,11 @@ export class BardSubclass extends Subclass {
       "10": CollegeOfWhispers.whispers10,
       "14": CollegeOfWhispers.whispers14,
       "15": CollegeOfWhispers.whispers15,
+    },
+    ELOQUENCE: {
+      "3": CollegeOfEloquence.eloquence3,
+      "6": CollegeOfEloquence.eloquence6,
+      "14": CollegeOfEloquence.eloquence14,
     },
     SWORDS: {
       "3": CollegeOfSwords.swords3,

--- a/src/Classes/Bard/Subclasses/Eloquence/CollegeOfEloquence.json
+++ b/src/Classes/Bard/Subclasses/Eloquence/CollegeOfEloquence.json
@@ -1,0 +1,32 @@
+{
+  "title": "College of Eloquence", 
+  "description": "Adherents of the College of Eloquence master the art of oratory. Persuasion is regarded as a high art, and a well-reasoned, well-spoken argument often proves more persuasive than facts. These bards wield a blend of logic and theatrical wordplay, winning over skeptics and detractors with logical arguments and plucking at heartstrings to appeal to the emotions of audiences.", 
+  "features": {
+    "3": {
+      "SILVER TONGUE": {
+        "title": "Silver Tongue", 
+        "description": "You are a master at saying the right thing at the right time. When you make a Charisma (Persuasion) or Charisma (Deception) check, you can treat a d20 roll of 9 or lower as a 10."
+      },
+      "UNSETTLING WORDS": {
+        "title": "Unsettling Words",
+        "description": "You can spin words laced with magic that unsettle a creature and cause it to doubt itself. As a bonus action, you can expend one use of your Bardic Inspiration and choose one creature you can see within 60 feet of you. Roll the Bardic Inspiration die. The creature must subtract the number rolled from the next saving throw it makes before the start of your next turn."
+      }
+    }, 
+    "6": {
+      "UNFAILING INSPIRATION": {
+        "title": "Unfailing Inspiration", 
+        "description": "Your inspiring words are so persuasive that others feel driven to succeed. When a creature adds one of your Bardic Inspiration dice to its ability check, attack roll, or saving throw and the roll fails, the creature can keep the Bardic Inspiration die."
+      },
+      "UNIVERSAL SPEECH": {
+        "title": "Universal Speech",
+        "description": "You have gained the ability to make your speech intelligible to any creature. As an action, choose one or more creatures within 60 feet of you, up to a number equal to your Charisma modifier (minimum of one creature). The chosen creatures can magically understand you, regardless of the language you speak, for 1 hour.\nOnce you use this feature, you can't use it again until you finish a long rest, unless you expend a spell slot to use it again."
+      }
+    }, 
+    "14": {
+      "INFECTIOUS INSPIRATION": {
+        "title": "Infectious Inspiration", 
+        "description": "When you successfully inspire someone, the power of your eloquence can now spread to someone else. When a creature within 60 feet of you adds one of your Bardic Inspiration dice to its ability check, attack roll, or saving throw and the roll succeeds, you can use your reaction to encourage a different creature (other than yourself) that can hear you within 60 feet of you, giving it a Bardic Inspiration die without expending any of your Bardic Inspiration uses.\nYou can use this reaction a number of times equal to your Charisma modifier (minimum of once), and you regain all expended uses when you finish a long rest."
+      }
+    }
+  }
+}

--- a/src/Classes/Bard/Subclasses/Eloquence/CollegeOfEloquence.ts
+++ b/src/Classes/Bard/Subclasses/Eloquence/CollegeOfEloquence.ts
@@ -1,0 +1,37 @@
+import { PlayerCharacter } from "../../../../Base/PlayerCharacter";
+import { LevelingParams } from "../../../PlayerClass";
+import * as CollegeOfEloquenceDict from "./CollegeOfEloquence.json";
+import { ResourceTrait, ScalingTrait, Trait } from "../../../../Base/Interfaces";
+
+export class CollegeOfEloquence {
+    
+  static getFeature(level: string, featureName: string) {
+      return CollegeOfEloquenceDict["features"][level][featureName];
+  }
+
+  static eloquence3(pc: PlayerCharacter, params: LevelingParams) {
+    pc.pcHelper.addFeatures(CollegeOfEloquence.getFeature("3", "SILVER TONGUE"));
+    pc.pcHelper.addFeatures(CollegeOfEloquence.getFeature("3", "UNSETTLING WORDS"));
+  }
+
+  static eloquence6(pc: PlayerCharacter, params: LevelingParams) {
+    pc.pcHelper.addFeatures(CollegeOfEloquence.getFeature("6", "UNIVERSAL SPEECH"));
+    pc.pcHelper.addFeatures(CollegeOfEloquence.getFeature("6", "UNFAILING INSPIRATION"));
+    const speech: ResourceTrait = {
+      title: "Universal Speech",
+      description: "The max number of creatures that can magically understand you for 1 hour",
+      resourceMax: (pc.abilityScores.charisma.modifier.value >=1) ? pc.abilityScores.charisma.modifier : {value: 1}
+    }
+    pc.pcHelper.addResourceTraits(speech);
+  }
+
+  static eloquence14(pc: PlayerCharacter, params: LevelingParams) {
+    pc.pcHelper.addFeatures(CollegeOfEloquence.getFeature("14", "INFECTIOUS INSPIRATION"));
+    const infect: ResourceTrait = {
+      title: "Infectious Inspiration",
+      description: "The number of times you may use Infectious Inspiration",
+      resourceMax: (pc.abilityScores.charisma.modifier.value >=1 ) ? pc.abilityScores.charisma.modifier : {value: 1}
+    }
+    pc.pcHelper.addResourceTraits(infect);
+  }  
+}

--- a/src/Classes/Bard/Subclasses/Glamour/CollegeOfGlamour.ts
+++ b/src/Classes/Bard/Subclasses/Glamour/CollegeOfGlamour.ts
@@ -25,7 +25,7 @@ export class CollegeOfGlamour {
   }
 
   static glamour6(pc: PlayerCharacter, params: LevelingParams) {
-    CollegeOfGlamour.getFeature("6", "MANTLE OF MAJESTY");
+    pc.pcHelper.addFeatures(CollegeOfGlamour.getFeature("6", "MANTLE OF MAJESTY"));
     pc.pcHelper.addSpells(["COMMAND"], "charisma");
   }
 

--- a/src/Classes/Wizard/Subclasses/WizardSubclass.ts
+++ b/src/Classes/Wizard/Subclasses/WizardSubclass.ts
@@ -1,4 +1,3 @@
-import { WarCaster } from "Feats/Feat";
 import { Subclass } from "../../Subclass";
 import { Abjuration } from "./Abjuration/Abjuration";
 import { Conjuration } from "./Conjuration/Conjuration";


### PR DESCRIPTION
Fixes to other files: Glamour was missing an apply for level 6 features, Wizard subclasses is important warcaster for no reason, same deal with universal speech and infectious inspiration. More words in the description to help references
