### PR TITLE
Initialize PC for Traits, Skills, etc. in Character Live Render

### DIFF
--- a/src/Utilities/Choice Build Specs/Choices.ts
+++ b/src/Utilities/Choice Build Specs/Choices.ts
@@ -44,7 +44,7 @@ export class PlayerFactory {
     }
 
     constructor() {
-        this.playerCharacter = null;
+        this.playerCharacter = new PlayerCharacter(0, 0, 0, 0, 0, 0);
     }
 
     setAbilityScore(name: string, score: number): void {


### PR DESCRIPTION
In constructor set `this.pc` to a new PlayerCharacter instead of null.